### PR TITLE
Scale up replicas

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: transactionprocessing
 spec:
-  replicas: 2
+  replicas: 3
   selector:
     matchLabels:
       app: transactionprocessing


### PR DESCRIPTION
This pull request includes a small change to the `k8s/deployment.yaml` file. The change increases the number of replicas for the `transactionprocessing` application from 2 to 3.